### PR TITLE
chore: add invariants, feature architect mode, and quickstart docs

### DIFF
--- a/.roo/rules-code/00-invariants.md
+++ b/.roo/rules-code/00-invariants.md
@@ -1,0 +1,10 @@
+# Invariants (Repo Defaults)
+
+Use these defaults unless the repo says otherwise:
+
+- Slice loop: AC → Plan (Files 1–2, Command 1, Artifact 1) → Tests-first → Minimal code → One command → Evidence
+- One command: prefer `npm run quickcheck` (or a single chained command)
+- Tests: prefer `node --test` (docs-only slices may declare **no-test-needed**)
+- Commit style: Conventional Commits
+- Canonical AC live in `docs/Acceptance-Criteria.md`
+- New chat per slice (fresh session)

--- a/.roo/rules-code/95-slice-backlog.md
+++ b/.roo/rules-code/95-slice-backlog.md
@@ -1,7 +1,6 @@
 # Slice Backlog Helper
-
-If the user didn't provide Acceptance Criteria:
-1) Open `docs/Slice-Backlog.md` (if present).
-2) Choose the first `[ ] TODO` slice that contains a ready block (AC + Plan).
-3) Propose that slice back to the user. If approved, proceed with tests-first and the plan.
-4) After completion, remind the user to mark it `[x] DONE` in `docs/Slice-Backlog.md`.
+If the user didn't paste AC:
+1) Open `docs/Slice-Backlog.md`.
+2) Pick the first `[ ] TODO` slice that includes a ready block (AC + Plan).
+3) Propose it back to the user. If approved, proceed tests-first with that plan.
+4) Remind the user to mark `[x] DONE` after completion.

--- a/.roo/rules-code/99-preflight.md
+++ b/.roo/rules-code/99-preflight.md
@@ -12,11 +12,10 @@ and include the TODO template below.
   - Show a short diff; ask which to keep; update the file accordingly, then proceed.
 - Otherwise (no AC anywhere) → **BLOCKED** and show the template.
 
-## 2) Small Plan
-- The user must give a 3-line plan:
-  - **Files:** name 1–2 files to change.
-  - **Command:** one command to run (e.g., `npm run quickcheck` or `pytest -q`).
-  - **Artifact:** one file or result to produce.
+## 2) Small Plan (3 lines, mandatory)
+- Files: name 1–2 paths only
+- Command: one command (e.g., `npm run quickcheck` or `node --test`)
+- Artifact: one file/result to produce
 - If missing → **BLOCKED**.
 
 ## 3) Tests First

--- a/.roomodes
+++ b/.roomodes
@@ -43,12 +43,29 @@
       ]
     },
     {
+      "slug": "feature-architect",
+      "name": "🧩 Feature Architect (mini)",
+      "description": "If an implementation plan already exists, produce a focused feature spec and update docs with minimal questions.",
+      "whenToUse": "When adding a new feature to an existing project with established PRD/UX/Implementation Guide.",
+      "roleDefinition": "You are the Feature Architect (mini). Read existing docs, ask at most 2 blocking questions, then append a concise feature plan and ready-to-paste slice to the docs.",
+      "customInstructions": "INPUTS:\n  - Read docs/ImplementationGuide.md, docs/PRD.md, docs/UX-Brief.md, docs/Slice-Backlog.md, docs/Assumptions.md.\nBEHAVIOR:\n  - If Implementation Guide exists and scope is clear: ask 0–2 clarifying questions max; otherwise proceed with best-effort assumptions (record them in docs/Assumptions.md).\nDELIVERABLES:\n  - Append to docs/ImplementationGuide.md a section `## Feature: <Title>` with: goal, constraints, data touchpoints, risks, test strategy (short).\n  - Append to docs/Slice-Backlog.md a new `[ ] TODO` with a ready block (AC 3–8 bullets + 3-line Plan) for the FIRST slice of this feature.\n  - Update docs/Tech-Choices.md only if this feature introduces a new dependency or version change.\nSTYLE:\n  - Be brief and implementation-ready; prefer concrete filenames, routes, and commands.\nHANDOFF:\n  - End by telling the user: \"Switch to Code mode and run the first slice for this feature.\"",
+      "groups": [
+        "read",
+        [
+          "edit",
+          { "fileRegex": "^(docs/(ImplementationGuide|Tech-Choices|Slice-Backlog|Assumptions)\\.md|docs/.*\\.md)$" }
+        ],
+        "browser",
+        "mcp"
+      ]
+    },
+    {
       "slug": "slice-spec",
       "name": "📝 Slice Spec Writer",
       "description": "Turn a one-line goal into Acceptance Criteria + a 3-line Plan and write them into docs.",
       "whenToUse": "Whenever you know the next goal and want the Acceptance Criteria + Plan created automatically.",
       "roleDefinition": "You are the Slice Spec Writer. Given a short goal from the user, you produce a tiny, testable slice spec:\n- Title (short)\n- Acceptance Criteria (3–8 checklist bullets)\n- Plan (Files 1–2, one Command, one Artifact)\nThen **append or update** a section in docs/Acceptance-Criteria.md for THIS slice,\nand (if docs/Slice-Backlog.md exists) add/update a matching `[ ] TODO` with the ready block.",
-      "customInstructions": "CONTEXT:\n  - Read if present: docs/ImplementationGuide.md, docs/PRD.md, docs/UX-Brief.md, docs/Slice-Backlog.md, docs/Assumptions.md.\nINTERACTION:\n  - Ask at most 2 clarifying questions only if blocking; otherwise proceed with best-effort assumptions (note them).\nOUTPUT FORMAT (chat):\n  - Show: Title, Acceptance Criteria (3–8 bullets), Plan (three lines), Assumptions (if any).\nFILE UPDATES:\n  - In docs/Acceptance-Criteria.md:\n      - Create the file if missing with a top-level heading.\n      - Add/update a new section:\n          ## [YYYY-MM-DD] slice: <kebab-id>\n          - [ ] bullet...\n  - In docs/Slice-Backlog.md (if present):\n      - Ensure there is a `[ ] TODO` item for <kebab-id>.\n      - Under a Ready Blocks area (or create one), insert the ready block (AC + Plan).\nNAMING:\n  - Derive <kebab-id> from the Title (lowercase, letters/numbers/dashes).\nHANDOFF:\n  - End by telling the user: \"Switch to Code mode and run this slice.\"",
+      "customInstructions": "CONTEXT:\n  - Read if present: docs/ImplementationGuide.md, docs/PRD.md, docs/UX-Brief.md, docs/Slice-Backlog.md, docs/Assumptions.md.\nINTERACTION:\n  - Ask at most 2 clarifying questions only if blocking; otherwise proceed with best-effort assumptions (note them).\nOUTPUT FORMAT (chat):\n  - Show: Title, Acceptance Criteria (3–8 bullets), Plan (three lines).\n  - Add a one-line 'Assumptions' note when you had to guess.\nFILE UPDATES:\n  - In docs/Acceptance-Criteria.md:\n      - Create the file if missing with a top-level heading.\n      - Insert an anchor: ## [YYYY-MM-DD] slice: <kebab-id>\n      - List the Acceptance Criteria bullets under that anchor.\n  - In docs/Slice-Backlog.md (if present):\n      - Ensure a `[ ] TODO` item for <kebab-id> with the ready block (AC + Plan).\nNAMING:\n  - Derive <kebab-id> from the Title (lowercase, letters/numbers/dashes) and reuse across docs.\nHANDOFF:\n  - End by telling the user: \"Switch to Code mode and run this slice.\"",
       "groups": [
         "read",
         ["edit", {"fileRegex": "^(docs/Acceptance-Criteria\\.md|docs/Slice-Backlog\\.md)$"}],

--- a/README.md
+++ b/README.md
@@ -1,1 +1,50 @@
 # Roo Spec Test Driven Development
+
+## Purpose
+Demonstrates a spec-first workflow for AI-assisted coding using the Roo Orchestrator.
+
+## Spec-Based AI Coding vs Vibe Coding
+Spec-Based AI Coding uses explicit Acceptance Criteria, a tiny plan, tests first, and one-command evidence so each commit is deliberate and reproducible.
+Vibe Coding lets the model "wing it" without a contract or tests, leading to unpredictable and harder-to-review changes.
+
+## Quick Start
+Paste this prompt into Roo task to bootstrap your project:
+
+```
+System objective: Bootstrap this repo with the Roo Orchestrator Framework.
+
+Do the following atomically:
+1) Detect OS (macOS/Linux or Windows PowerShell).
+2) Ask: "Which programming language does this project use?"
+   - Purpose: to update `.roo/rules-code/00-invariants.md` with language-specific commands and test tools.
+   - If the user asks why, reply: "This sets rule invariants so the agent follows standards for your language."
+3) In a temp directory, run:
+   git clone https://github.com/lukeorellana/roo-orchestrator-framework <temp>
+4) Copy into the current repo root:
+   - <temp>/.roomodes                       → .roomodes   (overwrite)
+   - <temp>/.roo/commands/**                → .roo/commands/ (merge/overwrite)
+   - <temp>/.roo-orchestrator/**            → .roo-orchestrator/ (merge/overwrite)
+5) Update `.roo/rules-code/00-invariants.md` with defaults for the chosen language
+   (e.g., Node: `npm run quickcheck` + `node --test`; Python: `pytest`; etc.)
+6) Print a short “Bootstrap OK” report listing created/updated paths.
+7) Do NOT modify any other files.
+
+Acceptance checks (must pass):
+- `.roomodes` present in repo root and contains the custom modes.
+- `.roo/commands/` exists and includes the slash commands (e.g., init/handoff/result/return).
+- `.roo/rules-code/00-invariants.md` reflects the selected language.
+- Final console output shows each path written.
+
+If shell access is unavailable, tell me exactly which commands to run for my OS instead of proceeding.
+
+Switch to Orchestrator mode in Roo.
+Initialize & interview: run /init-orchestrator. It will:
+Interview you in 3–4 rounds (vision/scope → current state → architecture → roadmap).
+Create/refresh .roo-orchestrator/Memory/Implementation_Plan.md and seed .roo-orchestrator/Memory/ entries.
+Build .roo-orchestrator/Memory/BACKLOG.md of ≤45-minute tasks with acceptance checks.
+If unknowns block progress, it will HANDOFF to Ask with top questions; if evidence is needed, HANDOFF to Code to run safe commands and paste outputs.
+Start the first tiny task: run /handoff-code, describe a ≤45m objective, files, commands, and acceptance tests.
+Code mode implements and returns a RESULT block with evidence.
+Orchestrator verifies evidence, updates .roo-orchestrator/Memory/ and .roo-orchestrator/Memory/BACKLOG.md, then /return-to-orchestrator to continue the loop.
+Repeat until done.
+```


### PR DESCRIPTION
## Summary
- establish default repo invariants for slice workflow and testing
- clarify preflight checks and backlog helper rules
- introduce a mini feature architect mode and refine slice spec writer instructions
- document project purpose, contrast spec-based AI coding with vibe coding, and provide a language-aware quickstart prompt

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68c597a24ac08333aa5fcd6ac8b76f1b