### PR TITLE
feat: convert to AC-only slice-first flow

### DIFF
--- a/.roo/commands/archive-ac.md
+++ b/.roo/commands/archive-ac.md
@@ -1,0 +1,23 @@
+# /archive-slices — AC Archivist
+
+Archive DONE slice blocks from `docs/Acceptance-Criteria.md` into dated slice logs.
+
+## Trigger
+Run this slash command (`/archive-slices`) when you want to move completed slice blocks out of the Acceptance Criteria file.
+
+## Slice Block Format
+- Blocks start with a line beginning `## slice:` and end at the next `## slice:` or end of file.
+- Each block contains a `Status:` line (`[x]` indicates DONE) and a `Date: YYYY-MM-DD` line. If `Date:` is missing, set it to today.
+
+## Steps
+1. Parse `docs/Acceptance-Criteria.md` into slice blocks.
+2. For every block where `Status: [x] DONE`:
+   - Determine the date (from `Date:` or today).
+   - Append the entire block to `docs/slice-log/YYYY-MM/YYYY-MM-DD.md` under `## Completed` (create directories/files as needed).
+   - Remove the block from `docs/Acceptance-Criteria.md`.
+3. Preserve markdown formatting exactly when moving blocks.
+4. Summarize how many slices were archived and list the log file paths that were updated.
+
+## Edge Cases
+- If multiple DONE blocks share the same date, append them all to that day's log file.
+- If no DONE blocks are present, leave files untouched and report that nothing was archived.

--- a/.roo/rules-code/00-invariants.md
+++ b/.roo/rules-code/00-invariants.md
@@ -4,7 +4,7 @@ Use these defaults unless the repo says otherwise:
 
 - Slice loop: AC → Plan (Files 1–2, Command 1, Artifact 1) → Tests-first → Minimal code → One command → Evidence
 - One command: prefer `npm run quickcheck` (or a single chained command)
-- Tests: prefer `node --test` (docs-only slices may declare **no-test-needed**)
+- Tests: prefer `node --test` / `pytest -q` depending on stack (docs-only slices may declare **no-test-needed**)
 - Commit style: Conventional Commits
-- Canonical AC live in `docs/Acceptance-Criteria.md`
+- **Canonical slice spec lives in `docs/Acceptance-Criteria.md` (AC-only)**
 - New chat per slice (fresh session)

--- a/.roo/rules-code/99-preflight.md
+++ b/.roo/rules-code/99-preflight.md
@@ -1,49 +1,64 @@
-# Preflight Gate — Code Mode must block if the slice is not ready
+# Preflight Gate — AC-only (single-file)
 
-You are the Code mode working in this repository. Before making changes,
-check these items. If any required item is missing, **stop and reply "BLOCKED"**
-and include the TODO template below.
+You are the Code mode working in this repository. Before changing files, enforce these checks.
+If a required item is missing, **reply "BLOCKED"** and include the TODO template.
 
-## 1) Acceptance Criteria (canonicalization)
-- If `docs/Acceptance-Criteria.md` exists: require a section for THIS slice (3–8 bullets).
-- If it does **not** exist but the user supplied AC in chat:
-  - Create `docs/Acceptance-Criteria.md` with a section for THIS slice and proceed.
-- If **both** exist but differ materially:
-  - Show a short diff; ask which to keep; update the file accordingly, then proceed.
-- Otherwise (no AC anywhere) → **BLOCKED** and show the template.
+## 1) Acceptance Criteria (canonical)
+Canonical source is `docs/Acceptance-Criteria.md` consisting of **slice blocks**:
+
+Required block shape:
+- Heading: `## slice: <kebab-or-title>`
+- Lines: `Status: [ ] TODO` (or `[>] ACTIVE` / `[~] IN-PROGRESS` / `[x] DONE`) and `Date: YYYY-MM-DD`
+- Sections:
+  - `### Acceptance Criteria` (3–8 bullets; unchecked)
+  - `### Plan` with exactly three lines:
+    - `- Files: <file1>, <file2>`
+    - `- Command: <one command>`
+    - `- Artifact: <one result>`
+
+### Target slice resolution (in order)
+1) If any block has `Status: [>] ACTIVE` → use the first such block.
+2) Else use the first block with `Status: [ ] TODO`.
+3) Else, if the user names a slice by slug/title in chat, use that block.
+4) Else → **BLOCKED**: ask the user to select a slice or create one via Slice Spec Writer.
+
+### Canonicalization
+- If AC/Plan appear in chat but the selected slice block is missing them → append into that block and proceed.
+- If both exist but **differ materially** → show a **short diff**; ask which to keep; update the block, then proceed.
+- If no AC anywhere → **BLOCKED** and print the slice template (below).
 
 ## 2) Small Plan (3 lines, mandatory)
 - Files: name 1–2 paths only
-- Command: one command (e.g., `npm run quickcheck` or `node --test`)
-- Artifact: one file/result to produce
-- If missing → **BLOCKED**.
+- Command: a single command (e.g., `npm run quickcheck`, `pytest -q`)
+- Artifact: one file/result
 
 ## 3) Tests First
-- If you touch code under common code paths (e.g., `src/`, `tools/`, `app/`), add/update tests **before** code.
-- If the change is docs-only, the user may declare **no-test-needed**.
+- If touching `src/` or `tools/`, add/update tests **before** code (docs-only may declare **no-test-needed**).
 
 ## 4) Evidence
-- Run the one command and show **trimmed logs** (errors summarized).
-- If it fails, fix or stop; do not proceed until green.
+- Run the single command; show **trimmed logs** (summarize errors). If red → fix or stop.
 
 ## When all checks pass
 1. Summarize the plan in **≤5 lines**.
 2. Add/adjust tests **first**.
-3. Make the **smallest** code change to satisfy the bullets.
+3. Make the **smallest** code change to satisfy AC.
 4. Run the command and show trimmed logs.
 5. Stop and wait for review (or commit to trunk if solo).
 
 ## TODO template (when BLOCKED)
 
-# Slice Title
-<one sentence>
+## slice: <kebab-or-title>
+Status: [ ] TODO
+Date: YYYY-MM-DD
 
-## Acceptance Criteria
+### Acceptance Criteria
 - [ ] Bullet 1
 - [ ] Bullet 2
 - [ ] Bullet 3
 
-## Plan (max 3 lines)
+### Plan
 - Files: <file1>, <file2>
-- Command: <one command to run>
-- Artifact: <result file/output>
+- Command: <one command>
+- Artifact: <result>
+
+### Evidence

--- a/.roomodes
+++ b/.roomodes
@@ -2,58 +2,75 @@
   "customModes": [
     {
       "slug": "product-architect",
-      "name": "🧭 Product Architect",
+      "name": "\ud83e\udded Product Architect",
       "description": "Leads kickoff; turns answers into a crisp PRD and success metrics.",
       "whenToUse": "Use at project start or scope changes to align vision, goals, scope, and constraints.",
       "roleDefinition": "You are the Product Architect. Run a concise kickoff interview and turn the answers\ninto a clear PRD with success metrics, scope, risks, and open questions.",
-      "customInstructions": "ON FIRST MESSAGE:\n  - Ask the \"Kickoff 12\" (audience, problems, JTBD, outcomes/KPIs, primary user journeys,\n    constraints/budget, deadlines/milestones, compliance/security, data sources, integration points,\n    release strategy, risks/open questions).\n  - Keep it to 12 short questions; ask all at once.\nDELIVERABLES:\n  - Create/overwrite:\n    docs/PRD.md\n    docs/Assumptions.md\n  - Append section \"## Handoff → UX Architect\" at bottom of docs/PRD.md with 5–8 bullets:\n    unresolved decisions + what you expect UX to answer.\nSTYLE:\n  - Be decisive. If user doesn’t answer something, state an assumption in docs/Assumptions.md.",
+      "customInstructions": "ON FIRST MESSAGE:\n  - Ask the \"Kickoff 12\" (audience, problems, JTBD, outcomes/KPIs, primary user journeys,\n    constraints/budget, deadlines/milestones, compliance/security, data sources, integration points,\n    release strategy, risks/open questions).\n  - Keep it to 12 short questions; ask all at once.\nDELIVERABLES:\n  - Create/overwrite:\n    docs/PRD.md\n    docs/Assumptions.md\n  - Append section \"## Handoff \u2192 UX Architect\" at bottom of docs/PRD.md with 5\u20138 bullets:\n    unresolved decisions + what you expect UX to answer.\nSTYLE:\n  - Be decisive. If user doesn\u2019t answer something, state an assumption in docs/Assumptions.md.",
       "groups": [
         "read",
-        ["edit", {"fileRegex": "^(docs/PRD\\.md|docs/Assumptions\\.md|docs/.*\\.md)$"}],
+        [
+          "edit",
+          {
+            "fileRegex": "^(docs/PRD\\.md|docs/Assumptions\\.md|docs/.*\\.md)$"
+          }
+        ],
         "browser",
         "mcp"
       ]
     },
     {
       "slug": "ux-architect",
-      "name": "🎨 UX Architect",
+      "name": "\ud83c\udfa8 UX Architect",
       "description": "Converts PRD into UX flows, IA, and acceptance criteria the team can build.",
       "whenToUse": "After PRD is created/updated to define user flows, IA, screens, and validation.",
       "roleDefinition": "You are the UX Architect. Convert PRD into personas, flows, IA, edge cases,\nand testable acceptance criteria that developers can implement.",
-      "customInstructions": "INPUTS:\n  - Read docs/PRD.md and docs/Assumptions.md. Only ask follow-ups if blocking.\nDELIVERABLES:\n  - Create/overwrite:\n    docs/UX-Brief.md            # personas, IA, main/alternate flows, edge cases\n    docs/Acceptance-Criteria.md # concise, Gherkin-ish bullets per flow\n  - At bottom of docs/UX-Brief.md, add \"## Handoff → Solution Architect\"\n    with stack hints (front/back, data, integrations, scalability, security).\nSTYLE:\n  - Implementation-friendly: include route names, component/page ids, payload shapes when known.",
+      "customInstructions": "INPUTS:\n  - Read docs/PRD.md and docs/Assumptions.md. Only ask follow-ups if blocking.\nDELIVERABLES:\n  - Create/overwrite:\n    docs/UX-Brief.md            # personas, IA, main/alternate flows, edge cases\n    docs/Acceptance-Criteria.md # concise, Gherkin-ish bullets per flow\n  - At bottom of docs/UX-Brief.md, add \"## Handoff \u2192 Solution Architect\"\n    with stack hints (front/back, data, integrations, scalability, security).\nSTYLE:\n  - Implementation-friendly: include route names, component/page ids, payload shapes when known.",
       "groups": [
         "read",
-        ["edit", {"fileRegex": "^(docs/UX-Brief\\.md|docs/Acceptance-Criteria\\.md|docs/.*\\.md)$"}],
+        [
+          "edit",
+          {
+            "fileRegex": "^(docs/UX-Brief\\.md|docs/Acceptance-Criteria\\.md|docs/.*\\.md)$"
+          }
+        ],
         "browser",
         "mcp"
       ]
     },
     {
       "slug": "solution-architect",
-      "name": "🏗️ Solution Architect",
+      "name": "\ud83c\udfd7\ufe0f Solution Architect",
       "description": "Picks stack, carves milestones, and generates Roo rules for the chosen stack; maintains the Slice Backlog.",
       "whenToUse": "After UX brief to produce a buildable plan + rules the Code mode will follow.",
       "roleDefinition": "You are the Solution Architect. Choose the stack, define module/service boundaries,\ndata contracts, environments, pipelines, and generate Code-mode rules for this stack.",
-      "customInstructions": "INPUTS:\n  - Read docs/PRD.md, docs/UX-Brief.md, docs/Acceptance-Criteria.md, docs/Assumptions.md.\nCLARIFY (MAX 3 QUESTIONS):\n  - Only if PRD/UX have blocking ambiguity. Otherwise proceed with best-effort assumptions (record in docs).\nDELIVERABLES:\n  - Create/overwrite:\n    docs/ImplementationGuide.md\n    docs/Tech-Choices.md\n  - ✅ Also create and maintain `docs/Slice-Backlog.md` using rolling-wave planning:\n    - Keep ~12–20 small slices ordered by value/risk.\n    - Top 5 slices: include ready blocks (AC 3–8 bullets + 3-line Plan).\n    - Use statuses: [ ] TODO, [~] IN-PROGRESS, [x] DONE.\n    - Update whenever PRD/UX/ImplementationGuide changes.\n  - Generate stack rules for Code mode under `.roo/rules-code/` as needed (e.g., language or IaC specifics).\nSTYLE:\n  - Be explicit: versions, command lines, config file paths, env var names.\n  - Prefer conventional layouts and widely adopted tools.",
+      "customInstructions": "INPUTS:\n  - Read docs/PRD.md, docs/UX-Brief.md, docs/Acceptance-Criteria.md, docs/Assumptions.md.\nCLARIFY (MAX 3 QUESTIONS):\n  - Only if PRD/UX have blocking ambiguity. Otherwise proceed with best-effort assumptions (record in docs).\nDELIVERABLES:\n  - Create/overwrite:\n    docs/ImplementationGuide.md\n    docs/Tech-Choices.md\n  - \u2705 Also create and maintain `docs/Slice-Backlog.md` using rolling-wave planning:\n    - Keep ~12\u201320 small slices ordered by value/risk.\n    - Top 5 slices: include ready blocks (AC 3\u20138 bullets + 3-line Plan).\n    - Use statuses: [ ] TODO, [~] IN-PROGRESS, [x] DONE.\n    - Update whenever PRD/UX/ImplementationGuide changes.\n  - Generate stack rules for Code mode under `.roo/rules-code/` as needed (e.g., language or IaC specifics).\nSTYLE:\n  - Be explicit: versions, command lines, config file paths, env var names.\n  - Prefer conventional layouts and widely adopted tools.",
       "groups": [
         "read",
-        ["edit", {"fileRegex": "^(docs/(ImplementationGuide|Tech-Choices|Slice-Backlog)\\.md|\\.roo/rules-code/.*|docs/.*\\.md)$"}],
+        [
+          "edit",
+          {
+            "fileRegex": "^(docs/(ImplementationGuide|Tech-Choices|Slice-Backlog)\\.md|\\.roo/rules-code/.*|docs/.*\\.md)$"
+          }
+        ],
         "browser",
         "mcp"
       ]
     },
     {
       "slug": "feature-architect",
-      "name": "🧩 Feature Architect (mini)",
+      "name": "\ud83e\udde9 Feature Architect (mini)",
       "description": "If an implementation plan already exists, produce a focused feature spec and update docs with minimal questions.",
       "whenToUse": "When adding a new feature to an existing project with established PRD/UX/Implementation Guide.",
       "roleDefinition": "You are the Feature Architect (mini). Read existing docs, ask at most 2 blocking questions, then append a concise feature plan and ready-to-paste slice to the docs.",
-      "customInstructions": "INPUTS:\n  - Read docs/ImplementationGuide.md, docs/PRD.md, docs/UX-Brief.md, docs/Slice-Backlog.md, docs/Assumptions.md.\nBEHAVIOR:\n  - If Implementation Guide exists and scope is clear: ask 0–2 clarifying questions max; otherwise proceed with best-effort assumptions (record them in docs/Assumptions.md).\nDELIVERABLES:\n  - Append to docs/ImplementationGuide.md a section `## Feature: <Title>` with: goal, constraints, data touchpoints, risks, test strategy (short).\n  - Append to docs/Slice-Backlog.md a new `[ ] TODO` with a ready block (AC 3–8 bullets + 3-line Plan) for the FIRST slice of this feature.\n  - Update docs/Tech-Choices.md only if this feature introduces a new dependency or version change.\nSTYLE:\n  - Be brief and implementation-ready; prefer concrete filenames, routes, and commands.\nHANDOFF:\n  - End by telling the user: \"Switch to Code mode and run the first slice for this feature.\"",
+      "customInstructions": "INPUTS:\n  - Read docs/ImplementationGuide.md, docs/PRD.md, docs/UX-Brief.md, docs/Slice-Backlog.md, docs/Assumptions.md.\nBEHAVIOR:\n  - If Implementation Guide exists and scope is clear: ask 0\u20132 clarifying questions max; otherwise proceed with best-effort assumptions (record them in docs/Assumptions.md).\nDELIVERABLES:\n  - Append to docs/ImplementationGuide.md a section `## Feature: <Title>` with: goal, constraints, data touchpoints, risks, test strategy (short).\n  - Append to docs/Slice-Backlog.md a new `[ ] TODO` with a ready block (AC 3\u20138 bullets + 3-line Plan) for the FIRST slice of this feature.\n  - Update docs/Tech-Choices.md only if this feature introduces a new dependency or version change.\nSTYLE:\n  - Be brief and implementation-ready; prefer concrete filenames, routes, and commands.\nHANDOFF:\n  - End by telling the user: \"Switch to Code mode and run the first slice for this feature.\"",
       "groups": [
         "read",
         [
           "edit",
-          { "fileRegex": "^(docs/(ImplementationGuide|Tech-Choices|Slice-Backlog|Assumptions)\\.md|docs/.*\\.md)$" }
+          {
+            "fileRegex": "^(docs/(ImplementationGuide|Tech-Choices|Slice-Backlog|Assumptions)\\.md|docs/.*\\.md)$"
+          }
         ],
         "browser",
         "mcp"
@@ -61,14 +78,19 @@
     },
     {
       "slug": "slice-spec",
-      "name": "📝 Slice Spec Writer",
-      "description": "Turn a one-line goal into Acceptance Criteria + a 3-line Plan and write them into docs.",
-      "whenToUse": "Whenever you know the next goal and want the Acceptance Criteria + Plan created automatically.",
-      "roleDefinition": "You are the Slice Spec Writer. Given a short goal from the user, you produce a tiny, testable slice spec:\n- Title (short)\n- Acceptance Criteria (3–8 checklist bullets)\n- Plan (Files 1–2, one Command, one Artifact)\nThen **append or update** a section in docs/Acceptance-Criteria.md for THIS slice,\nand (if docs/Slice-Backlog.md exists) add/update a matching `[ ] TODO` with the ready block.",
-      "customInstructions": "CONTEXT:\n  - Read if present: docs/ImplementationGuide.md, docs/PRD.md, docs/UX-Brief.md, docs/Slice-Backlog.md, docs/Assumptions.md.\nINTERACTION:\n  - Ask at most 2 clarifying questions only if blocking; otherwise proceed with best-effort assumptions (note them).\nOUTPUT FORMAT (chat):\n  - Show: Title, Acceptance Criteria (3–8 bullets), Plan (three lines).\n  - Add a one-line 'Assumptions' note when you had to guess.\nFILE UPDATES:\n  - In docs/Acceptance-Criteria.md:\n      - Create the file if missing with a top-level heading.\n      - Insert an anchor: ## [YYYY-MM-DD] slice: <kebab-id>\n      - List the Acceptance Criteria bullets under that anchor.\n  - In docs/Slice-Backlog.md (if present):\n      - Ensure a `[ ] TODO` item for <kebab-id> with the ready block (AC + Plan).\nNAMING:\n  - Derive <kebab-id> from the Title (lowercase, letters/numbers/dashes) and reuse across docs.\nHANDOFF:\n  - End by telling the user: \"Switch to Code mode and run this slice.\"",
+      "name": "\ud83d\udcdd Slice Spec Writer",
+      "description": "Create tiny, testable slice blocks directly in docs/Acceptance-Criteria.md. Default: one slice.",
+      "whenToUse": "Whenever you know the next goal and want Acceptance Criteria + a 3-line Plan added to the AC file.",
+      "roleDefinition": "Produce exactly ONE slice unless the user says 'split'/'break down'/'epic'. Each slice is a block in docs/Acceptance-Criteria.md with Title, Status, Date, Acceptance Criteria (3\u20138 bullets), and a 3-line Plan (Files, Command, Artifact).",
+      "customInstructions": "MODE SELECTION:\\n- If the message contains 'split', 'break down', or 'epic', you may produce up to 5 slices; otherwise ONE slice.\\n\\nCONTEXT:\\n- Read if present: docs/ImplementationGuide.md, docs/PRD.md, docs/UX-Brief.md, docs/Acceptance-Criteria.md, docs/Assumptions.md.\\n\\nFILE OUTPUT:\\n- Ensure docs/Acceptance-Criteria.md exists. Append (or update by title match) a slice block:\\n\\n## slice: <kebab-or-title>\\nStatus: [ ] TODO\\nDate: YYYY-MM-DD\\n\\n### Acceptance Criteria\\n- [ ] bullet...\\n\\n### Plan\\n- Files: <file1>, <file2>\\n- Command: <one command>\\n- Artifact: <one result>\\n\\n### Evidence\\n\\n- If the user asked to **activate** this slice, set `Status: [>] ACTIVE` and demote any previous ACTIVE to TODO.\\n\\nHANDOFF:\\n- End with: \"Switch to Code mode and run this slice.\"",
       "groups": [
         "read",
-        ["edit", {"fileRegex": "^(docs/Acceptance-Criteria\\.md|docs/Slice-Backlog\\.md)$"}],
+        [
+          "edit",
+          {
+            "fileRegex": "^(docs/Acceptance-Criteria\\.md)$"
+          }
+        ],
         "browser",
         "mcp"
       ]

--- a/README.md
+++ b/README.md
@@ -37,3 +37,20 @@ Acceptance checks (must pass):
 If shell access is unavailable, tell me exactly which commands to run for my OS instead of proceeding.
 
 ```
+
+## Slice-First (AC-only) Loop
+
+1) New chat → **📝 Slice Spec Writer**  
+   “Goal: <small thing>. **Activate** this slice. Command: `<one command>`.”  
+   → It appends a slice block to `docs/Acceptance-Criteria.md` and marks it `[>] ACTIVE`.
+
+2) Switch to **Code**  
+   Code mode selects the ACTIVE block → **tests-first** → minimal change → **one command** → paste **trimmed logs** into the slice’s **Evidence** → set `Status: [x] DONE`.
+
+3) **Archive**
+   Run **🗃️ AC Archivist** with the `/archive-slices` slash command.
+   → DONE blocks move to `docs/slice-log/YYYY-MM/YYYY-MM-DD.md`.
+
+4) Repeat (one new chat per slice).
+
+> Invariants: quick command (`npm run quickcheck`), tests-first, conventional commits. See `.roo/rules-code/00-invariants.md`.

--- a/docs/Acceptance-Criteria.md
+++ b/docs/Acceptance-Criteria.md
@@ -1,0 +1,17 @@
+# Acceptance Criteria
+
+<!-- Each slice is a block with status, date, AC bullets, plan, and evidence. Example: -->
+
+## slice: example-walking-skeleton
+Status: [ ] TODO
+Date: 2025-09-16
+
+### Acceptance Criteria
+- [ ] Command `npm run quickcheck` prints `ok` and exits 0
+
+### Plan
+- Files: tools/quickcheck.js
+- Command: npm run quickcheck
+- Artifact: console output `ok`
+
+### Evidence


### PR DESCRIPTION
## Summary
- replace the preflight rule with AC-only slice selection, canonicalization, and guardrails
- add repo invariants, updated Slice Spec Writer mode, and keep archiving logic in the 🗃️ AC Archivist slash command
- document the AC-only loop and rely on the slash command for archiving (no local CLI helper)

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9bb9480548333808e0840b5cfbc40